### PR TITLE
New Module: @mgfx/testing

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ export const fork = {
 };
 
 export const validate = {
+  any: resolve as Validator<any>,
   void: (() => resolve(undefined)) as Validator<void>,
   string: ((value: unknown) =>
     typeof value === 'string'

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@mgfx/testing",
+  "version": "0.0.0",
+  "main": "dist/index.js",
+  "license": "MIT",
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ai-labs-team/mgFx.git"
+  },
+  "scripts": {
+    "clean": "rimraf dist",
+    "build": "tsc -p tsconfig.json",
+    "test": "jest"
+  },
+  "bugs": {
+    "url": "https://github.com/ai-labs-team/mgFx/issues"
+  },
+  "dependencies": {
+    "fast-deep-equal": "3.1.1",
+    "mgfx": "^0.6.6"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/testing/src/index.test.ts
+++ b/packages/testing/src/index.test.ts
@@ -1,0 +1,216 @@
+import { implement, define, validate } from 'mgfx';
+import { reject } from 'fluture';
+
+import {
+  mockConnector,
+  ExpectedResolutionFailedError,
+  ExpectedRejectionFailedError,
+  UnmatchedRunChildError,
+} from './index';
+
+let didRun = false;
+const setDidRun = implement(
+  define({ name: 'setDidRun', input: validate.any, output: validate.any }),
+  (value) => {
+    didRun = value;
+  }
+);
+
+const callChild = implement(
+  define({ name: 'callChild', input: validate.void, output: validate.void }),
+  (value, { runChild }) => runChild(setDidRun(true))
+);
+
+beforeEach(() => {
+  didRun = false;
+});
+
+describe('.run().withInput()', () => {
+  it('runs an implementation with input', async () => {
+    await mockConnector().run(setDidRun).withInput(true).promise();
+    expect(didRun).toBe(true);
+  });
+
+  it('rejects if an un-stubbed child Task is attempted', async () => {
+    const test = mockConnector().run(callChild).withInput().promise();
+
+    await expect(test).rejects.toBeInstanceOf(UnmatchedRunChildError);
+    await expect(test).rejects.toHaveProperty(
+      'message',
+      `Task 'callChild' attempted to run child Task 'setDidRun'. Use '.stub()' to provide a stubbed implementation for 'setDidRun'.`
+    );
+
+    await expect(test).rejects.toHaveProperty('parentProcess', {
+      id: expect.any(String),
+      input: undefined,
+      spec: callChild.spec,
+      context: undefined,
+    });
+
+    await expect(test).rejects.toHaveProperty('childProcess', {
+      id: expect.any(String),
+      parentId: expect.any(String),
+      input: true,
+      spec: setDidRun.spec,
+      context: undefined,
+    });
+  });
+});
+
+describe('.expect', () => {
+  const identity = implement(
+    define({ name: 'identity', input: validate.any, output: validate.any }),
+    (value) => (value === 'oopsie' ? reject(new Error('nope')) : value)
+  );
+
+  describe('.resolution()', () => {
+    it('resolves when an implementation resolves to an equal value', async () => {
+      await mockConnector()
+        .run(identity)
+        .withInput({ testingEquality: true })
+        .expect.resolution({ testingEquality: true })
+        .promise();
+    });
+
+    it('rejects when an implementation resolves to an un-equal value', async () => {
+      const test = mockConnector()
+        .run(identity)
+        .withInput({ testingEquality: 'true' })
+        .expect.resolution({ testingEquality: true })
+        .promise();
+
+      await expect(test).rejects.toBeInstanceOf(ExpectedResolutionFailedError);
+      await expect(test).rejects.toHaveProperty('expected', {
+        testingEquality: true,
+      });
+      await expect(test).rejects.toHaveProperty('actual', {
+        testingEquality: 'true',
+      });
+      await expect(test).rejects.toHaveProperty('isRejection', false);
+      await expect(test).rejects.toHaveProperty(
+        'message',
+        'Task resolved with a different result to what was expected.'
+      );
+    });
+
+    it('rejects when an implementation rejects', async () => {
+      const test = mockConnector()
+        .run(identity)
+        .withInput('oopsie')
+        .expect.resolution('oopsie')
+        .promise();
+
+      await expect(test).rejects.toBeInstanceOf(ExpectedResolutionFailedError);
+      await expect(test).rejects.toHaveProperty('expected', 'oopsie');
+      await expect(test).rejects.toHaveProperty('actual', new Error('nope'));
+      await expect(test).rejects.toHaveProperty('isRejection', true);
+      await expect(test).rejects.toHaveProperty(
+        'message',
+        'Task rejected when it was expected to resolve.'
+      );
+    });
+
+    it('is aliased as `expect()`', async () => {
+      await mockConnector()
+        .run(identity)
+        .withInput({ testingEquality: true })
+        .expect({ testingEquality: true })
+        .promise();
+    });
+  });
+
+  describe('.rejection()', () => {
+    it('resolves when an implementation rejects with an equal reason', async () => {
+      await mockConnector()
+        .run(identity)
+        .withInput('oopsie')
+        .expect.rejection(new Error('nope'))
+        .promise();
+    });
+
+    it('rejects when an implementation rejects with an un-equal reason', async () => {
+      const test = mockConnector()
+        .run(identity)
+        .withInput('oopsie')
+        .expect.rejection(new Error('oh no!'))
+        .promise();
+
+      await expect(test).rejects.toBeInstanceOf(ExpectedRejectionFailedError);
+      await expect(test).rejects.toHaveProperty(
+        'expected',
+        new Error('oh no!')
+      );
+      await expect(test).rejects.toHaveProperty('actual', new Error('nope'));
+      await expect(test).rejects.toHaveProperty('isResolution', false);
+      await expect(test).rejects.toHaveProperty(
+        'message',
+        'Task rejected with a different reason to what was expected.'
+      );
+    });
+
+    it('rejects when an implementation resolves', async () => {
+      const test = mockConnector()
+        .run(identity)
+        .withInput('howdy')
+        .expect.rejection(new Error('nope'))
+        .promise();
+
+      await expect(test).rejects.toBeInstanceOf(ExpectedRejectionFailedError);
+      await expect(test).rejects.toHaveProperty('expected', new Error('nope'));
+      await expect(test).rejects.toHaveProperty('actual', 'howdy');
+      await expect(test).rejects.toHaveProperty('isResolution', true);
+      await expect(test).rejects.toHaveProperty(
+        'message',
+        'Task resolved when it was expected to reject.'
+      );
+    });
+  });
+});
+
+describe('.stub()', () => {
+  const getTime = implement(
+    define({
+      name: 'getTime',
+      input: validate.string,
+      output: validate.number,
+    }),
+    () => 24
+  );
+
+  const greet = implement(
+    define({
+      name: 'greet',
+      input: validate.string,
+      output: validate.string,
+    }),
+    (name, { runChild }) =>
+      runChild(getTime('24h'))
+        .map((hours) => (hours >= 12 ? 'afternoon' : 'morning'))
+        .map((time) => `Good ${time}, ${name}!`)
+  );
+
+  describe('.as()', () => {
+    it('stubs Task definitions with the given function', async () => {
+      expect.assertions(1);
+
+      await mockConnector()
+        .stub(getTime)
+        .as((input) => {
+          expect(input).toBe('24h');
+          return 11;
+        })
+        .run(greet)
+        .withInput('World')
+        .expect('Good morning, World!')
+        .promise();
+
+      await mockConnector()
+        .stub(getTime)
+        .as(() => 16)
+        .run(greet)
+        .withInput('World')
+        .expect('Good afternoon, World!')
+        .promise();
+    });
+  });
+});

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,0 +1,136 @@
+import { localConnector } from 'mgfx';
+import { NoImplementationError } from 'mgfx/dist/connector/local';
+import {
+  Definition,
+  Implementation,
+  InputOf,
+  OutputOf,
+  Process,
+  implement,
+  ImplementationFunction,
+  Spec,
+} from 'mgfx/dist/task';
+
+import {
+  bichain,
+  chain,
+  chainRej,
+  resolve,
+  reject,
+  FutureInstance,
+} from 'fluture';
+
+import { CustomError } from 'ts-custom-error';
+import fastEquals from 'fast-deep-equal';
+
+export const mockConnector = () => {
+  const connector = localConnector();
+
+  const run = <I extends Implementation>(implementation: I) => {
+    connector.serve(implementation);
+
+    const withInput = (input: InputOf<I['spec']>) => {
+      const future = implementation(input).pipe((processF) =>
+        connector
+          .run(processF)
+          .pipe(matchUnmatchedRunChildError(implementation.spec, processF))
+      );
+
+      const expect = (expected: OutputOf<I['spec']>) =>
+        future.pipe(matchResolution(expected));
+
+      return Object.assign(future, {
+        expect: Object.assign(expect, {
+          resolution: expect,
+          rejection: (expected: any) => future.pipe(matchRejection(expected)),
+        }),
+      });
+    };
+
+    return { withInput };
+  };
+
+  const stub = <D extends Definition>(definition: D) => {
+    const as = (stub: ImplementationFunction<D['spec']>) => {
+      connector.serve(implement(definition, stub));
+
+      return self;
+    };
+
+    return { as };
+  };
+
+  const self = { run, stub };
+  return self;
+};
+
+export const matchResolution = (expected: any) =>
+  bichain<any, ExpectedResolutionFailedError, void>((actual) =>
+    reject(new ExpectedResolutionFailedError(expected, actual, true))
+  )((actual) =>
+    fastEquals(expected, actual)
+      ? resolve(undefined)
+      : reject(new ExpectedResolutionFailedError(expected, actual))
+  );
+
+export const matchRejection = (expected: any) =>
+  bichain<any, ExpectedRejectionFailedError, void>((actual) =>
+    fastEquals(expected, actual)
+      ? resolve(undefined)
+      : reject(new ExpectedRejectionFailedError(expected, actual))
+  )((actual) =>
+    reject(new ExpectedRejectionFailedError(expected, actual, true))
+  );
+
+export const matchUnmatchedRunChildError = (
+  spec: Spec,
+  processF: FutureInstance<any, Process>
+) =>
+  chainRej((reason: any) =>
+    reason instanceof NoImplementationError
+      ? processF.pipe(
+          chain((parentProcess) =>
+            reject(new UnmatchedRunChildError(parentProcess, reason.process))
+          )
+        )
+      : reject(reason)
+  );
+
+export class ExpectedResolutionFailedError extends CustomError {
+  constructor(
+    public readonly expected: any,
+    public readonly actual: any,
+    public readonly isRejection = false
+  ) {
+    super(
+      isRejection
+        ? 'Task rejected when it was expected to resolve.'
+        : 'Task resolved with a different result to what was expected.'
+    );
+  }
+}
+
+export class ExpectedRejectionFailedError extends CustomError {
+  constructor(
+    public readonly expected: any,
+    public readonly actual: any,
+    public readonly isResolution = false
+  ) {
+    super(
+      isResolution
+        ? 'Task resolved when it was expected to reject.'
+        : 'Task rejected with a different reason to what was expected.'
+    );
+  }
+}
+
+export class UnmatchedRunChildError extends CustomError {
+  constructor(
+    public readonly parentProcess: Process,
+    public readonly childProcess: Process
+  ) {
+    super(
+      `Task '${parentProcess.spec.name}' attempted to run child Task '${childProcess.spec.name}'. Use '.stub()' to provide a stubbed implementation for '${childProcess.spec.name}'.`
+    );
+  }
+}

--- a/packages/testing/tsconfig.json
+++ b/packages/testing/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.common.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7911,15 +7911,15 @@ fast-copy@^2.0.5:
   resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-2.0.5.tgz#ddf558bc3c1dd15782da69327adbf4f79499dc50"
   integrity sha512-KVLihIS41LzwuXJFdUm5NstoBfAmhCPCzhn362CX2IklaPrzQRtCedzrpPa7Ff/OVbNMUSJJFqx5+4yp07NmbQ==
 
+fast-deep-equal@3.1.1, fast-deep-equal@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
+  integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
+
 fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
-
-fast-deep-equal@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
-  integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
 
 fast-equals@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Implements #5 

Introduces an API that provides a simple pattern for:

- Running an mgFx task within the context of a headless test runner
- Asserting the output of a Task
- Stubbing out `.runChild()` invocations

Future improvements:

- A helper module that installs `expect()` adapters for popular test runners for better test runner integration.
- Pre-built implementation stubs for common patterns (`always`/`sequence`/`repeatingSequence`/etc)
- Snapshot-based testing