### PR TITLE
'Heartbeat' Feature

### DIFF
--- a/packages/analyzer-gui/src/common.tsx
+++ b/packages/analyzer-gui/src/common.tsx
@@ -12,7 +12,8 @@ const STATE_INTENTS: Record<Span['state'], Intent> = {
   running: 'none',
   resolved: 'success',
   rejected: 'danger',
-  cancelled: 'warning'
+  cancelled: 'warning',
+  dead: 'warning'
 };
 
 export const stateIntent = (span: Span): Intent => STATE_INTENTS[span.state];
@@ -36,6 +37,10 @@ export const stateIcon = ({ span, size }: { span: Span; size?: number }) => {
 
   if (span.state === 'cancelled') {
     return 'warning-sign';
+  }
+
+  if (span.state === 'dead') {
+    return 'outdated';
   }
 
   return undefined;

--- a/packages/analyzer-gui/src/routes/Explore/Inspector/IOTab.tsx
+++ b/packages/analyzer-gui/src/routes/Explore/Inspector/IOTab.tsx
@@ -32,6 +32,20 @@ export const IOTab: React.FC<Props> = ({ span }) => {
       );
     }
 
+    if (span.state === 'dead') {
+      const last = span.heartbeat?.last
+        ? new Date(span.heartbeat.last).toLocaleString()
+        : undefined;
+
+      return (
+        <NonIdealState
+          icon="outdated"
+          title="Process is not responding"
+          description={last ? `Last heartbeat received at ${last}` : 'No heartbeat received.'}
+        />
+      );
+    }
+
     return <ObjectInspector data={span.output} theme={theme} />;
   }, [span.state]);
 

--- a/packages/analyzer-gui/src/routes/Explore/Inspector/SummaryTab.tsx
+++ b/packages/analyzer-gui/src/routes/Explore/Inspector/SummaryTab.tsx
@@ -44,7 +44,22 @@ export const SummaryTab: React.FC<Props> = ({ span }) => {
         </>
       );
     }
+
+    if (span.state === 'dead') {
+      return (
+        <>
+          <dt className={Classes.TEXT_MUTED}>Assumed Dead At</dt>
+          <dd>{endedAt}</dd>
+        </>
+      );
+    }
   }, [span, span.state]);
+
+  const lastHeartbeat = React.useMemo(() => {
+    return span.heartbeat?.last
+      ? new Date(span.heartbeat.last).toLocaleString()
+      : 'Never';
+  }, [span.heartbeat?.last]);
 
   const duration = React.useMemo(() => {
     return ('endedAt' in span ? span.endedAt : Date.now()) - span.createdAt;
@@ -82,6 +97,8 @@ export const SummaryTab: React.FC<Props> = ({ span }) => {
           {titleCase(span.state)}
         </Tag>
       </dd>
+      <dt className={Classes.TEXT_MUTED}>Last Heartbeat</dt>
+      <dd>{lastHeartbeat}</dd>
       {finishedAt}
       <dt className={Classes.TEXT_MUTED}>Duration</dt>
       <dd>{duration.toLocaleString()} ms</dd>

--- a/packages/analyzer-gui/src/routes/Explore/Timeline.scss
+++ b/packages/analyzer-gui/src/routes/Explore/Timeline.scss
@@ -218,7 +218,8 @@ $font-size-small: 10px;
       );
     }
 
-    &.cancelled {
+    &.cancelled,
+    &.dead {
       @include span(
         map-get($pt-intent-text-colors, 'warning'),
         rgba($pt-intent-warning, 0.15),

--- a/packages/analyzer-http-server/src/index.test.ts
+++ b/packages/analyzer-http-server/src/index.test.ts
@@ -47,11 +47,13 @@ afterAll(async () => {
 
 describe('/collector', () => {
   it('collects events received via HTTP', async () => {
+    const now = Date.now();
+
     await request(app)
       .post('/analyzer/collector')
       .set('Accept', 'application/json')
       .send({
-        timestamp: 1,
+        timestamp: now,
         kind: 'process',
         process: {
           spec: {
@@ -72,7 +74,7 @@ describe('/collector', () => {
     expect(runningResponse.body).toEqual([
       {
         id: 'test-1',
-        createdAt: 1,
+        createdAt: now,
         process: {
           spec: {
             name: 'test',
@@ -87,7 +89,7 @@ describe('/collector', () => {
       .post('/analyzer/collector')
       .set('Accept', 'application/json')
       .send({
-        timestamp: 2,
+        timestamp: now + 1,
         kind: 'resolution',
         id: 'test-1',
         value: 'world',
@@ -103,8 +105,8 @@ describe('/collector', () => {
     expect(resolvedResponse.body).toEqual([
       {
         id: 'test-1',
-        createdAt: 1,
-        endedAt: 2,
+        createdAt: now,
+        endedAt: now + 1,
         process: {
           spec: {
             name: 'test',

--- a/packages/analyzer-http-server/src/index.ts
+++ b/packages/analyzer-http-server/src/index.ts
@@ -62,6 +62,9 @@ const queryParams = {
           }),
         }),
       ]),
+      heartbeat: t.type({
+        livenessThreshold: t.number
+      }),
       compact: t.boolean,
     })
   ),
@@ -127,8 +130,16 @@ const cancellationEvent = t.intersection([
   }),
 ]);
 
+const heartbeatEvent = t.intersection([
+  baseEvent,
+  t.type({
+    kind: t.literal('heartbeat'),
+    id: t.string
+  })
+])
+
 const event = ioTs(
-  t.union([processEvent, resolutionEvent, rejectionEvent, cancellationEvent])
+  t.union([processEvent, resolutionEvent, rejectionEvent, cancellationEvent, heartbeatEvent])
 );
 
 const decodeQuery = <T>(

--- a/packages/analyzer-storage-postgresql/src/index.ts
+++ b/packages/analyzer-storage-postgresql/src/index.ts
@@ -18,8 +18,8 @@ const pgp = pgPromise(opts);
 export const postgresql: Initializer<Config> = (config) => {
   /**
    *  Timestamps are persisted with the Postgres type 'bigint'; we make the (rather bold) assumption that the only
-   *  bigint's we'll be dealing as actual column values are timestamps, and therefore OK to parse via `parseInt`. That
-   *  gives us until 2038 to find a better solution.
+   *  bigint's we'll be dealing as actual column values are timestamps, and therefore OK to parse via `parseInt` since
+   *  they'll always be less than `Number.MAX_SAFE_INTEGER`.
    */
   pgp.pg.types.setTypeParser(pgp.pg.types.builtins.INT8, parseInt);
 

--- a/packages/analyzer-storage-postgresql/src/migrations/1593690989177_heartbeats.ts
+++ b/packages/analyzer-storage-postgresql/src/migrations/1593690989177_heartbeats.ts
@@ -1,0 +1,262 @@
+import { MigrationBuilder } from 'node-pg-migrate';
+
+export const up = async (pgm: MigrationBuilder) => {
+  pgm.addColumn('spans', {
+    heartbeat: {
+      type: 'jsonb'
+    }
+  });
+
+  pgm.createFunction('upsert_span', [], {
+    replace: true,
+    language: 'plpgsql',
+    returns: 'TRIGGER'
+  }, `
+BEGIN
+  CASE (NEW.event ->> 'kind')
+    WHEN 'process' THEN
+      /**
+       * When 'kind' is 'process', create and insert a new 'span' record
+       */
+      INSERT INTO spans
+      VALUES (
+        -- id
+        (NEW.event #>> '{process,id}')::uuid,
+
+        -- parentId
+        (NEW.event #>> '{process,parentId}')::uuid,
+
+        -- createdAt
+        (NEW.event ->> 'timestamp')::bigint,
+
+        -- process
+        jsonb_build_object('spec', jsonb_build_object('name', NEW.event #>> '{process,spec,name}')),
+
+        -- input
+        NEW.event #> '{process,input}',
+
+        -- context
+        NEW.event #> '{process,context}',
+
+        -- state
+        'running'
+      )
+      /**
+       * In the edge cases where the result event was received before the process event, a Span will already exist, so
+       * we need to 'fill in' the missing columns that are only available from a 'process' event.
+       */
+      ON CONFLICT (id) DO UPDATE
+      SET
+        "parentId" = EXCLUDED."parentId",
+        "createdAt" = EXCLUDED."createdAt",
+        process = EXCLUDED.process,
+        input = EXCLUDED.input,
+        context = EXCLUDED.context,
+        state = COALESCE(spans.state, EXCLUDED.state);
+
+    WHEN 'rejection' THEN
+      /**
+       * To ensure that the Span definitely exists (either partially or completely), we attempt an insert first.
+       */
+      INSERT INTO spans (
+        id,
+        "endedAt",
+        state,
+        output
+      )
+      VALUES (
+        (NEW.event ->> 'id')::uuid,
+        (NEW.event ->> 'timestamp')::bigint,
+        'rejected',
+        (NEW.event -> 'reason')
+      )
+      /**
+       * If the insert fails due to a conflicting 'id', then it's because the 'process' handler above already created a
+       * Span, so just update the existing one.
+       */
+      ON CONFLICT (id) DO UPDATE
+      SET
+        "endedAt" = EXCLUDED."endedAt",
+        state = 'rejected',
+        output = EXCLUDED.output;
+
+    WHEN 'resolution' THEN
+      INSERT INTO spans (
+        id,
+        "endedAt",
+        state,
+        output
+      )
+      VALUES (
+        (NEW.event ->> 'id')::uuid,
+        (NEW.event ->> 'timestamp')::bigint,
+        'resolved',
+        (NEW.event -> 'value')
+      )
+      ON CONFLICT (id) DO UPDATE
+      SET
+        "endedAt" = EXCLUDED."endedAt",
+        state = 'resolved',
+        output = EXCLUDED.output;
+
+    WHEN 'cancellation' THEN
+      INSERT INTO spans (
+        id,
+        "endedAt",
+        state
+      )
+      VALUES (
+        (NEW.event ->> 'id')::uuid,
+        (NEW.event ->> 'timestamp')::bigint,
+        'cancelled'
+      )
+      ON CONFLICT (id) DO UPDATE
+      SET
+        "endedAt" = EXCLUDED."endedAt",
+        state = 'cancelled',
+        output = NULL;
+
+    WHEN 'heartbeat' THEN
+      INSERT INTO spans (
+        id,
+        heartbeat
+      )
+      VALUES (
+        (NEW.event ->> 'id')::uuid,
+        jsonb_build_object('last', (NEW.event ->> 'timestamp')::bigint)
+      )
+      ON CONFLICT (id) DO UPDATE
+      SET
+        heartbeat = EXCLUDED.heartbeat
+      WHERE
+        (spans.heartbeat -> 'last') IS NULL OR
+        (spans.heartbeat -> 'last') < (EXCLUDED.heartbeat -> 'last');
+
+  END CASE;
+
+  RETURN NULL;
+END;
+`);
+};
+
+export const down = async (pgm: MigrationBuilder) => {
+  pgm.createFunction(
+    'upsert_span',
+    [],
+    {
+      replace: true,
+      language: 'plpgsql',
+      returns: 'TRIGGER',
+    },
+    `
+BEGIN
+  CASE (NEW.event ->> 'kind')
+    WHEN 'process' THEN
+      /**
+       * When 'kind' is 'process', create and insert a new 'span' record
+       */
+      INSERT INTO spans
+      VALUES (
+        -- id
+        (NEW.event #>> '{process,id}')::uuid,
+
+        -- parentId
+        (NEW.event #>> '{process,parentId}')::uuid,
+
+        -- createdAt
+        (NEW.event ->> 'timestamp')::bigint,
+
+        -- process
+        jsonb_build_object('spec', jsonb_build_object('name', NEW.event #>> '{process,spec,name}')),
+
+        -- input
+        NEW.event #> '{process,input}',
+
+        -- context
+        NEW.event #> '{process,context}',
+
+        -- state
+        'running'
+      )
+      /**
+       * In the edge cases where the result event was received before the process event, a Span will already exist, so
+       * we need to 'fill in' the missing columns that are only available from a 'process' event.
+       */
+      ON CONFLICT (id) DO UPDATE
+      SET
+        "parentId" = EXCLUDED."parentId",
+        "createdAt" = EXCLUDED."createdAt",
+        process = EXCLUDED.process,
+        input = EXCLUDED.input,
+        context = EXCLUDED.context;
+
+    WHEN 'rejection' THEN
+      /**
+       * To ensure that the Span definitely exists (either partially or completely), we attempt an insert first.
+       */
+      INSERT INTO spans (
+        id,
+        "endedAt",
+        state,
+        output
+      )
+      VALUES (
+        (NEW.event ->> 'id')::uuid,
+        (NEW.event ->> 'timestamp')::bigint,
+        'rejected',
+        (NEW.event -> 'reason')
+      )
+      /**
+       * If the insert fails due to a conflicting 'id', then it's because the 'process' handler above already created a
+       * Span, so just update the existing one.
+       */
+      ON CONFLICT (id) DO UPDATE
+      SET
+        "endedAt" = EXCLUDED."endedAt",
+        state = 'rejected',
+        output = EXCLUDED.output;
+
+    WHEN 'resolution' THEN
+      INSERT INTO spans (
+        id,
+        "endedAt",
+        state,
+        output
+      )
+      VALUES (
+        (NEW.event ->> 'id')::uuid,
+        (NEW.event ->> 'timestamp')::bigint,
+        'resolved',
+        (NEW.event -> 'value')
+      )
+      ON CONFLICT (id) DO UPDATE
+      SET
+        "endedAt" = EXCLUDED."endedAt",
+        state = 'resolved',
+        output = EXCLUDED.output;
+
+    WHEN 'cancellation' THEN
+      INSERT INTO spans (
+        id,
+        "endedAt",
+        state
+      )
+      VALUES (
+        (NEW.event ->> 'id')::uuid,
+        (NEW.event ->> 'timestamp')::bigint,
+        'cancelled'
+      )
+      ON CONFLICT (id) DO UPDATE
+      SET
+        "endedAt" = EXCLUDED."endedAt",
+        state = 'cancelled',
+        output = NULL;
+  END CASE;
+
+  RETURN NULL;
+END;
+`
+  );
+
+  pgm.dropColumn('spans', 'heartbeat');
+};

--- a/packages/analyzer-storage-sqlite/src/index.ts
+++ b/packages/analyzer-storage-sqlite/src/index.ts
@@ -4,6 +4,7 @@ import {
   RejectionEvent,
   ResolutionEvent,
   CancellationEvent,
+  HeartbeatEvent
 } from 'mgfx/dist/middleware/instrumenter';
 import { fluent } from 'mgfx/dist/utils/fluenture';
 import { Initializer, Storage } from '@mgfx/analyzer/dist/storage';
@@ -46,6 +47,7 @@ export const sqlite: Initializer<Partial<Config>> = (config) => {
   const putEventRejection = db.prepare(statements.putEventRejection);
   const putEventResolution = db.prepare(statements.putEventResolution);
   const putEventCancellation = db.prepare(statements.putEventCancellation);
+  const putEventHeartbeat = db.prepare(statements.putEventHeartbeat);
 
   const cachedValueId = (value: any) => {
     const result = getCachedValue.get(value);
@@ -90,6 +92,15 @@ export const sqlite: Initializer<Partial<Config>> = (config) => {
 
     cancellation: db.transaction((event: CancellationEvent) => {
       putEventCancellation.run({
+        timestamp: event.timestamp,
+        id: event.id,
+      });
+
+      updateSpan.run(event.id);
+    }),
+
+    heartbeat: db.transaction((event: HeartbeatEvent) => {
+      putEventHeartbeat.run({
         timestamp: event.timestamp,
         id: event.id,
       });

--- a/packages/analyzer-storage-sqlite/src/migrations/005-heartbeats.sql
+++ b/packages/analyzer-storage-sqlite/src/migrations/005-heartbeats.sql
@@ -1,0 +1,112 @@
+-- Up
+CREATE TABLE "events_heartbeat" (
+    "timestamp" INTEGER,
+    "id" TEXT,
+    PRIMARY KEY("id", "timestamp")
+);
+
+ALTER TABLE spans ADD "last_heartbeat" INTEGER;
+
+DROP VIEW "computed_spans";
+CREATE VIEW "computed_spans" AS
+    SELECT
+        process_id AS id,
+        process_parent_id AS parent_id,
+        events_process.timestamp AS created_at,
+        events_process.process_spec_name,
+        input_id,
+        events_process.context_id AS context_id,
+        events_process.context_parent_id AS context_parent_id,
+        events_process.context_values_id AS context_values_id,
+        CASE
+            WHEN events_resolution.id IS NOT NULL THEN 1
+            WHEN events_rejection.id IS NOT NULL THEN 2
+            WHEN events_cancellation.id IS NOT NULL THEN 3
+            ELSE 0
+        END AS state,
+        COALESCE(
+          events_rejection.timestamp,
+          events_resolution.timestamp,
+          events_cancellation.timestamp
+        ) AS ended_at,
+        COALESCE(
+          events_rejection.reason_id,
+          events_resolution.value_id
+        ) AS output_id,
+        latest_heartbeats.timestamp AS last_heartbeat
+    FROM events_process
+    LEFT JOIN events_resolution
+        ON events_resolution.id = events_process.process_id
+    LEFT JOIN events_rejection
+        ON events_rejection.id = events_process.process_id
+    LEFT JOIN events_cancellation
+        ON events_cancellation.id = events_process.process_id
+    LEFT JOIN (
+        SELECT
+            id,
+            MAX(timestamp) AS timestamp
+        FROM events_heartbeat
+        GROUP BY id
+    ) AS latest_heartbeats ON (latest_heartbeats.id = events_process.process_id)
+
+-- Down
+DROP TABLE "events_heartbeat";
+
+ALTER TABLE "spans" RENAME TO "_spans";
+
+CREATE TABLE "spans" (
+	"id"	TEXT,
+	"parent_id"	TEXT,
+	"created_at"	INTEGER,
+	"process_spec_name"	TEXT,
+	"input_id"	INTEGER,
+	"context_id"	TEXT,
+	"context_parent_id"	TEXT,
+	"context_values_id"	INTEGER NOT NULL,
+	"state"	INTEGER,
+	"ended_at"	INTEGER,
+	"output_id"	INTEGER,
+	FOREIGN KEY("input_id") REFERENCES "value_cache",
+	FOREIGN KEY("context_values_id") REFERENCES "value_cache",
+	FOREIGN KEY("output_id") REFERENCES "value_cache",
+	PRIMARY KEY("id")
+) WITHOUT ROWID;
+
+INSERT INTO spans
+  SELECT * FROM _spans;
+
+DROP TABLE _spans;
+
+DROP VIEW "computed_spans";
+CREATE VIEW "computed_spans" AS
+    SELECT
+        process_id AS id,
+        process_parent_id AS parent_id,
+        events_process.timestamp AS created_at,
+        events_process.process_spec_name,
+        input_id,
+        events_process.context_id AS context_id,
+        events_process.context_parent_id AS context_parent_id,
+        events_process.context_values_id AS context_values_id,
+        CASE
+            WHEN events_resolution.id IS NOT NULL THEN 1
+            WHEN events_rejection.id IS NOT NULL THEN 2
+            WHEN events_cancellation.id IS NOT NULL THEN 3
+            ELSE 0
+        END AS state,
+        COALESCE(
+          events_rejection.timestamp,
+          events_resolution.timestamp,
+          events_cancellation.timestamp
+        ) AS ended_at,
+        COALESCE(
+          events_rejection.reason_id,
+          events_resolution.value_id
+        ) AS output_id
+    FROM events_process
+    LEFT JOIN events_resolution
+        ON events_resolution.id = events_process.process_id
+    LEFT JOIN events_rejection
+        ON events_rejection.id = events_process.process_id
+    LEFT JOIN events_cancellation
+        ON events_cancellation.id = events_process.process_id

--- a/packages/analyzer-storage-sqlite/src/statements.ts
+++ b/packages/analyzer-storage-sqlite/src/statements.ts
@@ -81,6 +81,19 @@ INSERT INTO events_cancellation (
 `;
 
 /**
+ * Inserts a row into the `events_heartbeat` table; used to store Events where `event.kind === 'heartbeat'`
+ */
+export const putEventHeartbeat = `
+INSERT INTO events_heartbeat (
+  timestamp,
+  id
+) VALUES (
+  $timestamp,
+  $id
+)
+`;
+
+/**
  * Updates a row in the `spans` table based upon the result of the `computed_spans` view for a specific process ID
  */
 export const updateSpan = `

--- a/packages/analyzer-storage-sqlite/src/utils.ts
+++ b/packages/analyzer-storage-sqlite/src/utils.ts
@@ -4,6 +4,7 @@ import {
   RejectionEvent,
   ResolutionEvent,
   CancellationEvent,
+  HeartbeatEvent,
 } from 'mgfx/dist/middleware/instrumenter';
 import { value, error } from '@mgfx/codecs';
 import { FutureInstance, parallel, resolve } from 'fluture';
@@ -15,6 +16,7 @@ export const switchEvent = <T, D>(fns: {
   rejection: (event: RejectionEvent, data?: D) => T;
   resolution: (event: ResolutionEvent, data?: D) => T;
   cancellation: (event: CancellationEvent, data?: D) => T;
+  heartbeat: (event: HeartbeatEvent, data?: D) => T;
 }) => (event: Event, data?: D): T => {
   if (event.kind === 'process') {
     return fns.process(event, data);
@@ -32,6 +34,10 @@ export const switchEvent = <T, D>(fns: {
     return fns.cancellation(event, data);
   }
 
+  if (event.kind === 'heartbeat') {
+    return fns.heartbeat(event, data);
+  }
+
   throw new Error('Invalid event kind');
 };
 
@@ -47,4 +53,6 @@ export const encodeEvent = switchEvent<FutureInstance<any, any>, never>({
   resolution: (event) => value.encode(event.value),
 
   cancellation: () => resolve(undefined),
+
+  heartbeat: () => resolve(undefined),
 });

--- a/packages/analyzer/src/query.ts
+++ b/packages/analyzer/src/query.ts
@@ -5,6 +5,7 @@
 import { Observable } from 'kefir';
 import { FutureInstance } from 'fluture';
 import { Values } from 'mgfx/dist/context';
+import { HeartbeatConfig } from 'mgfx/dist/middleware/instrumenter';
 
 /**
  * The parameters which may be specified when querying for a list of Spans.
@@ -75,6 +76,19 @@ export type SpanParameters = Partial<{
     | 'output'
     | { input: { path: string[] } }
     | { output: { path: string[] } };
+
+  heartbeat: {
+    /**
+     * If specified, Processes are considered 'dead' if their last heartbeat was more than this number of milliseconds
+     * ago.
+     * 
+     * This should be equal to or greater than the `heartbeat.interval` option passed to `makeAnalyzer` (which defaults
+     * to 60 seconds.)
+     * 
+     * If omitted, defaults to `heartbeat.interval * 1.5`.
+     */
+    livenessThreshold: number;
+  }
 }>;
 
 /**
@@ -95,11 +109,15 @@ export type Span = {
     parentId: string;
     values?: Values;
   };
+  heartbeat?: {
+    last: number;
+  }
 } & (
   | { state: 'running' }
   | { state: 'resolved'; endedAt: number; output?: any }
   | { state: 'rejected'; endedAt: number; output?: any }
   | { state: 'cancelled'; endedAt: number }
+  | { state: 'dead'; endedAt: number }
 );
 
 /**

--- a/packages/core/src/middleware/instrumenter.ts
+++ b/packages/core/src/middleware/instrumenter.ts
@@ -2,7 +2,7 @@
  * A specialized application of Middleware that can observe the progression and settlement of Task executions, intended
  * for a way of analyzing the run-time behaviour of mgFx-powered applications.
  */
-import { map, bimap, FutureInstance } from 'fluture';
+import { bimap, Future, FutureInstance, race } from 'fluture';
 
 import { Process, Spec } from '../task';
 import { MiddlewareFn } from '../middleware';
@@ -39,19 +39,36 @@ export type CancellationEvent = BaseEvent & {
   id: string;
 };
 
+export type HeartbeatEvent = BaseEvent & {
+  kind: 'heartbeat';
+  id: string;
+};
+
 export type Event =
   | ProcessEvent
   | ResolutionEvent
   | RejectionEvent
-  | CancellationEvent;
+  | CancellationEvent
+  | HeartbeatEvent;
+
+export type Receiver = (event: Event) => void;
 
 /**
  * The configuration options that should be passed to `makeInstrumenter` when making a specialized Instrumenter.
- * The `sink` function will receive every Event that is seen by the Instrumenter.
+ * The `receiver` function will receive every Event that is seen by the Instrumenter.
  */
 export type Config = {
-  receiver: (event: Event) => void;
+  receiver: Receiver;
+  heartbeat?: HeartbeatConfig;
 };
+
+/**
+ * Configuration options that are specific to the 'heartbeat' functionality, which sends Events at the interval (in
+ * milliseconds) specified by `interval`. Set to `0` to disable heartbeat functionality.
+ */
+export type HeartbeatConfig = {
+  interval?: number;
+}
 
 const timestamp = () => Date.now();
 
@@ -60,50 +77,82 @@ const tap = <T>(fn: (value: T) => any) => (value: T) => {
   return value;
 };
 
+const makeHeartbeatMonitor = (receiver: Receiver, config: HeartbeatConfig) => (
+  process: Process
+) =>
+  race(
+    Future(() => {
+      const interval = setInterval(() => {
+        receiver({
+          kind: 'heartbeat',
+          timestamp: timestamp(),
+          id: process.id,
+        });
+      }, config.interval);
+
+      return () => {
+        clearInterval(interval);
+      };
+    })
+  );
+
 /**
  * Creates a Middleware function that:
  * - Emits `process` Events *before* a Process begins execution.
  * - Emits `rejection` or `resolutions` Events *after* a Process has completed (successfully or unsuccessfully).
  * - Emits `cancellation` Events whenever a Process was cancelled.
+ * - Emits `heartbeat` Events at a configurable interval as long as the Process is running.
  */
 export const makeInstrumenter = (
   config: Config
-): MiddlewareFn<Process, FutureInstance<any, any>> => (process, next) => {
-  config.receiver({
-    kind: 'process',
-    timestamp: timestamp(),
-    process,
-  });
+): MiddlewareFn<Process, FutureInstance<any, any>> => {
+  const { heartbeat, receiver } = config;
 
-  return next(process)
-    .pipe(
-      bimap(
-        tap((reason) => {
-          config.receiver({
-            kind: 'rejection',
-            timestamp: timestamp(),
-            id: process.id,
-            reason,
-          });
-        })
-      )(
-        tap((value) => {
-          config.receiver({
-            kind: 'resolution',
-            timestamp: timestamp(),
-            id: process.id,
-            value,
-          });
-        })
+  const heartbeatMonitor = heartbeat?.interval
+    ? makeHeartbeatMonitor(receiver, heartbeat)
+    : undefined;
+
+  return (process, next) => {
+    receiver({
+      kind: 'process',
+      timestamp: timestamp(),
+      process,
+    });
+
+    const dispatch = next(process)
+      .pipe(
+        bimap(
+          tap((reason) => {
+            receiver({
+              kind: 'rejection',
+              timestamp: timestamp(),
+              id: process.id,
+              reason,
+            });
+          })
+        )(
+          tap((value) => {
+            receiver({
+              kind: 'resolution',
+              timestamp: timestamp(),
+              id: process.id,
+              value,
+            });
+          })
+        )
       )
-    )
-    .pipe(
-      tapCancellation(() => {
-        config.receiver({
-          kind: 'cancellation',
-          timestamp: timestamp(),
-          id: process.id,
-        });
-      })
-    );
+      .pipe(
+        tapCancellation(() => {
+          receiver({
+            kind: 'cancellation',
+            timestamp: timestamp(),
+            id: process.id,
+          });
+        })
+      );
+
+      return heartbeatMonitor
+        ? dispatch.pipe(heartbeatMonitor(process))
+        : dispatch;
+  };
 };


### PR DESCRIPTION
This PR introduces the 'heartbeat' feature described in #19: 

- Adds the ability for the the built-in 'Instrumenter' middleware to send 'heartbeat' events at intervals as long as a Process is running.
- Adds handlers for the SQLite and PostgreSQL analyzer engines to store these events and infer the last time a 'heartbeat' signal was received for a given Process. When a Process is still running but the last heartbeat is older than the 'liveness threshold', then the Process will instead be considered 'dead'.
- Modifies the decoder used by the HTTP Server to allow 'heartbeat' events.