### PR TITLE
Add indexes to SQLite and Postgresql storage providers for common fields

### DIFF
--- a/packages/analyzer-storage-postgresql/src/migrations/1597921314948_indexes.ts
+++ b/packages/analyzer-storage-postgresql/src/migrations/1597921314948_indexes.ts
@@ -1,0 +1,9 @@
+import { MigrationBuilder } from 'node-pg-migrate';
+
+export const up = async (pgm: MigrationBuilder) => {
+  pgm.createIndex('spans', 'createdAt');
+};
+
+export const down = async (pgm: MigrationBuilder) => {
+  pgm.dropIndex('spans', 'createdAt');
+};

--- a/packages/analyzer-storage-sqlite/src/migrations/006-indexes.sql
+++ b/packages/analyzer-storage-sqlite/src/migrations/006-indexes.sql
@@ -1,0 +1,6 @@
+-- Up
+CREATE INDEX created_at ON spans (created_at);
+CREATE INDEX process_spec_name ON spans (process_spec_name);
+
+-- Down
+DROP INDEX created_at;


### PR DESCRIPTION
Adding some indexes for fields that commonly form part of `WHERE` and `ORDER BY` clauses due to the Analyzer's higher-level query syntax.

On SQLite, we didn't have indexes for `created_at` or `process_spec_name`, therefore requiring a full scan for simple queries based on time or Task name.

On Postgresql, we didn't have an index for `createdAt`, therefore requiring a full scan for simple time-based queries.

These initial indexing improvements are somewhat naive; ultimately these index definitions are dictated by how the respective query planners operate over common mgFx-specific queries. This will likely need further refinement over time.