### PR TITLE
feat: implement configurable retention mechanism

### DIFF
--- a/packages/analyzer-http-client/src/index.ts
+++ b/packages/analyzer-http-client/src/index.ts
@@ -3,8 +3,9 @@ import { Analyzer, Span } from '@mgfx/analyzer';
 import { value } from '@mgfx/codecs';
 import copy from 'fast-copy';
 import { patch } from 'jsondiffpatch';
-import { map, chain, encaseP, fork } from 'fluture';
+import { map, chain, encaseP, fork, never } from 'fluture';
 import { stream } from 'kefir';
+import { fluent } from 'mgfx/dist/utils/fluenture';
 
 export type Config = {
   baseUrl: string;
@@ -35,6 +36,8 @@ export const httpClient = (config: Config): Analyzer => {
     receiver,
 
     collector: makeInstrumenter({ receiver }),
+
+    retention: never.pipe(fluent),
 
     query: {
       spans: (params) => {

--- a/packages/analyzer-storage-postgresql/src/queries/retention.sql
+++ b/packages/analyzer-storage-postgresql/src/queries/retention.sql
@@ -1,0 +1,7 @@
+DELETE
+FROM events
+WHERE (event -> 'timestamp')::bigint < (EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000) - ${maxAge};
+
+DELETE
+FROM spans
+WHERE "endedAt" < (EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000) - ${maxAge};

--- a/packages/analyzer/src/retention.ts
+++ b/packages/analyzer/src/retention.ts
@@ -1,0 +1,41 @@
+import { Fluenture, fluent } from 'mgfx/dist/utils/fluenture';
+import { after, go, FutureInstance, reject } from 'fluture';
+
+import { Storage } from '.';
+
+export type Config = {
+  maxAge: number;
+  checkInterval: number;
+};
+
+export type ExpireOptions = Omit<Config, 'checkInterval'>;
+
+export type Expire = (options: ExpireOptions) => FutureInstance<any, number>;
+
+export type Options = {
+  storage: Fluenture<any, Storage>,
+  config?: Config
+};
+
+export type Handler = Fluenture<any, never>;
+
+export const makeHandler = ({ storage, config }: Options): Handler => {
+  if (!config) {
+    return reject('Retention has not been configured').pipe(fluent);
+  }
+
+  return storage
+    .map((storage) => {
+      if (!storage.expire) {
+        throw new Error('Storage does support Retention.');
+      }
+
+      return storage.expire;
+    })
+    .chain((expire) => go(function* () {
+      while (true) {
+        yield expire({ maxAge: config.maxAge });
+        yield after(config.checkInterval)(undefined);
+      }
+    }));
+  };

--- a/packages/analyzer/src/storage.ts
+++ b/packages/analyzer/src/storage.ts
@@ -1,6 +1,7 @@
 import { FutureInstance } from 'fluture';
 import { Event } from 'mgfx/dist/middleware/instrumenter';
 import { SpanParameters, Span } from './query';
+import { Expire } from './retention';
 
 /**
  * A Storage provider must be capable of accepting Instrumentation events via `put.event` and storing them in
@@ -17,6 +18,7 @@ export type Storage = {
   query: {
     spans: (params: SpanParameters) => FutureInstance<any, Span[]>;
   };
+  expire?: Expire;
 };
 
 export type Initializer<Config> = (


### PR DESCRIPTION
Implements #4

Adds 'retention' options to Analyzer config:

- `maxAge` (number) - the 'age' (in milliseconds) of a Process at which it will be considered 'expired' and deleted from storage.
- `checkInterval` (number) - the time to wait (in milliseconds) between performing expiration runs.

The Analyzer object now contains a `retention` property; this is a Future that will perform a cleanup of Process data older than `maxAge`, every `checkInterval` seconds. This Future represents a long-running process, and as such, it never resolves. However, it will reject if retention has not been explicitly configured via the options above, or if some other error condition is encountered during it's operation. Like all Futures, it must be explicitly forked in order to execute, and may be cancelled to terminate the cancellation process.