### PR TITLE
Set Correlation-Id header only when defined

### DIFF
--- a/packages/task-http-request/src/index.ts
+++ b/packages/task-http-request/src/index.ts
@@ -39,10 +39,9 @@ export const httpRequest = implement(
         url,
         method,
         data,
-        headers: {
-          ...headers,
-          'Correlation-Id': correlationId
-        }
+        headers: correlationId
+          ? {...headers, 'Correlation-Id': correlationId}
+          : headers,
       })
         .then((response: any) =>
           resolve(


### PR DESCRIPTION
Some APIs will return error responses when some headers are set, even if blank. This update ensures that `Correlation-Id` is only set if defined in the task