### PR TITLE
Change default display mode from list to tree

### DIFF
--- a/packages/analyzer-gui-common/config.ts
+++ b/packages/analyzer-gui-common/config.ts
@@ -26,7 +26,7 @@ export type WatchKey = <K extends Key>(
 ) => () => void;
 
 export const defaults: Config = {
-  logDisplayMode: 'list',
+  logDisplayMode: 'tree',
   logParameters: {
     limit: 100,
     order: {


### PR DESCRIPTION
Changes the default analyzer-gui display mode from list to tree.
![image](https://user-images.githubusercontent.com/70483566/167901848-65c21925-b85f-43e2-a143-115ce1ca9ef5.png)
